### PR TITLE
Fix failing build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,7 +192,7 @@ RUN chown $OPENSHIFT_ORIGIN_USER_ID:$OPENSHIFT_ORIGIN_USER_ID \
 # /usr/pgsql-10/bin/.
 RUN ln -sf /usr/pgsql-10/bin/psql /usr/bin/psql && \
     ln -sf /usr/pgsql-10/bin/pg_dump /usr/bin/pg_dump && \
-    ln -sf /usr/pgsql-10/bin/pg_restore /usr/bin/pg_restore && \
+    ln -sf /usr/pgsql-10/bin/pg_restore /usr/bin/pg_restore
 
 # Add the user OpenShift Origin will run the image built by this Dockerfile to
 # the system. This is required because PostgreSQL executables, such as psql and


### PR DESCRIPTION
On OpenShift Origin v3.11:

`oc new-build https://github.com/adrianbartyczak/openshift-postgresql-10-postgis-img-lib --name=postgresql-10-centos7-postgis --build-arg OPENSHIFT_ORIGIN_USER_ID=1000170000`

was failing due to extra backslash. After this fix its working fine.